### PR TITLE
Bug/typesense health check

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -12,7 +12,7 @@ sites:
   - name: Plausible Analytics
     url: https://plausible.acmuic.org
   - name: ACM@UIC Website Typsense
-    url: https://typesense.acmuic.org
+    url: https://typesense.acmuic.org/health
   - name: Pathfinder
     url: https://umpf.acmuic.org
 


### PR DESCRIPTION
Noticed that the endpoint that Upptime is checking for Typesense is returning a 404 even when the service is up.

The `/health` endpoint should be a better indicator of when the application is up and ready to serve requests.

Additional documentation can be found here: https://typesense.org/docs/guide/install-typesense.html#%F0%9F%86%97-health-check